### PR TITLE
custom build / release automation using goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /tmp
 /out-tsc
+/dist
 
 # dependencies
 vendor

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,38 @@
-# Customise builds
 builds:
-  - main: ./app/main.go
-  - binary: kauri-api
-    goos:
-      - windows
-      - darwin
-      - linux
-    goarch:
-      - amd64
+- main: ./app/main
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  binary: kauri-api-{{Date}}-{{Tag}}
+  flags:
+    - -tags
+    - dev
+- env:
+  - CGO_ENABLED=0
+archive:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  wrap_in_directory: true
+  format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+snapshot:
+  name_template: SNAPSHOT-{{.Commit}}
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - Merge
+sign:
+   artifacts: checksum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,20 +1,19 @@
 builds:
 - main: ./app/main
   env:
-  - CGO_ENABLED=0
+    - CGO_ENABLED=0
   goos:
-  - linux
-  - darwin
+    - linux
+    - darwin
   goarch:
-  - amd64
-  binary: kauri-api-{{Date}}-{{Tag}}
-  flags:
-    - -tags
-    - dev
-- env:
-  - CGO_ENABLED=0
+    - 386
+    - amd64
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: 386
 archive:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   replacements:
     darwin: Darwin
     linux: Linux
@@ -25,10 +24,6 @@ archive:
   format_overrides:
     - goos: windows
       format: zip
-checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
-snapshot:
-  name_template: SNAPSHOT-{{.Commit}}
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 builds:
-- main: ./app/main
+- main: ./app/main.go
   env:
     - CGO_ENABLED=0
   goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,6 @@ archive:
     windows: Windows
     386: i386
     amd64: x86_64
-  wrap_in_directory: true
   format_overrides:
     - goos: windows
       format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,10 @@
+# Customise builds
+builds:
+    main: ./app/main.go
+  - binary: kauri-api
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 # Customise builds
 builds:
-    main: ./app/main.go
+  - main: ./app/main.go
   - binary: kauri-api
     goos:
       - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ after_failure:
 
 # Customise builds
 builds:
-    main: ./app/main.go
+  - main: ./app/main.go
   - binary: kauri-api
     goos:
       - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 sudo: false
 
+notifications:
+  email: false
+
 go:
   - 1.9.5
   - 1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: go
 
 sudo: false
 
-notifications:
-  email: false
-
 go:
   - 1.9.5
   - 1.10.x
@@ -104,7 +101,7 @@ builds:
     goarch:
       - amd64
 
-# Initiate release sequence
+# Initiate deploy sequence via goreleaser
 deploy:
 - provider: script
   skip_cleanup: true
@@ -112,6 +109,9 @@ deploy:
   on:
     tags: true
     condition: $TRAVIS_OS_NAME = linux
+
+notifications:
+  email: false
 
 env:
   secure: pfgvIn/dxcLiboFyy5EAMpAMXT5bFNhm00XCpITU88c2WhG664v8ym9zi6Oa0R4iO3Ua+Bf52bLdEwjVJVch/Vxb+l4ZzCoGrpavTLdg6dTBe2FKxev1NKQmO7/ZJzVNR38BFQ/AeG6rCXhyChbRhLubsz2CpjLw1eH3qUZjqyPxp4Mx1HrENAjTyqTJN7MEMwFbN5a4wtUqDq7zshh8YL2IB2RvKH0VkT00pp+2K2uNEpGQ4V0AY1x9AB8UJ+dKk9as+qwdWWTjNPIkFLXGXlc6FaWQMtA0WQ/Yua5pxoYKecFJrxMSJEPMNSR/SCd6qsILg9dMUEpsMfLZLPUdMlEu/xN0FPm+vmHxyZQbcyRQZm0IxJu8Y7re9xz9IMy3zF0sRPi2Bm3dxE93jfDkPw/TyuUjX3aJt/ykOf7yCcu2pF0OiH7LoShwYbXzot+a6j6Zg1bviShe7oqCdtP9HgkoMlvb72MKn/9TAj5HR30T2CAOF8rdqIvnrGKu4BuURDAnKaR8dweWThWfr7/kYWce7O76HlcQ8iU5Lnt5hJ7wlyQM6wvk+M/4coRkC4SYFgPHjUwUUzocQI9Oyn5Dw+SBXJT+ViA6GpcpeY8Oa5SlfUWgkupaJEK46GSKlBage/8uz48YbUytFCOsIvM6ZgSI2kjxiIjgTp/Aaokepog=

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,25 @@ after_failure:
 - chmod +x send.sh
 - "./send.sh failure $WEBHOOK_URL"
 
+# Customise builds
+builds:
+  - binary: kauri-api
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+
+# Initiate release sequence
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+
 env:
   secure: pfgvIn/dxcLiboFyy5EAMpAMXT5bFNhm00XCpITU88c2WhG664v8ym9zi6Oa0R4iO3Ua+Bf52bLdEwjVJVch/Vxb+l4ZzCoGrpavTLdg6dTBe2FKxev1NKQmO7/ZJzVNR38BFQ/AeG6rCXhyChbRhLubsz2CpjLw1eH3qUZjqyPxp4Mx1HrENAjTyqTJN7MEMwFbN5a4wtUqDq7zshh8YL2IB2RvKH0VkT00pp+2K2uNEpGQ4V0AY1x9AB8UJ+dKk9as+qwdWWTjNPIkFLXGXlc6FaWQMtA0WQ/Yua5pxoYKecFJrxMSJEPMNSR/SCd6qsILg9dMUEpsMfLZLPUdMlEu/xN0FPm+vmHxyZQbcyRQZm0IxJu8Y7re9xz9IMy3zF0sRPi2Bm3dxE93jfDkPw/TyuUjX3aJt/ykOf7yCcu2pF0OiH7LoShwYbXzot+a6j6Zg1bviShe7oqCdtP9HgkoMlvb72MKn/9TAj5HR30T2CAOF8rdqIvnrGKu4BuURDAnKaR8dweWThWfr7/kYWce7O76HlcQ8iU5Lnt5hJ7wlyQM6wvk+M/4coRkC4SYFgPHjUwUUzocQI9Oyn5Dw+SBXJT+ViA6GpcpeY8Oa5SlfUWgkupaJEK46GSKlBage/8uz48YbUytFCOsIvM6ZgSI2kjxiIjgTp/Aaokepog=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ after_failure:
 
 # Customise builds
 builds:
+    main: ./app/main.go
   - binary: kauri-api
     goos:
       - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ language: go
 sudo: false
 
 go:
-  - 1.10.1
+  - 1.9.5
+  - 1.10.x
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
 
 go_import_path: github.com/Encrypt-S/kauri-api
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
sane configs setup with ability to run goreleaser from local machine and via Travis CI. 

test release artefacts for tag v0.0.1 can be viewed here:
https://github.com/Encrypt-S/kauri-api/releases

I also tried the very manual approach but was happier with the workflow and outcome that goreleaser provided. 

@red010b37 we can easily add/subtract `goos` and `goarch` build specs as needed in time, but this initial config should get us going. let me know if you want any changes though. 

output from successful goreleaser output run from local machine below (signed):
```
❯ goreleaser

   • releasing using goreleaser 0.77.0...
   • loading config file       file=.goreleaser.yml
   • SETTING DEFAULTS FOR:
      • loading environment variables
      • snapshoting
      • releasing to GitHub
      • project name
      • creating archives
      • building binaries
      • creating Linux packages with fpm
      • creating Linux packages with nfpm
      • creating Linux packages with snapcraft
      • calculating checksums
      • signing artifacts
      • creating Docker images
      • releasing to Artifactory
      • releasing to s3
      • creating homebrew formula
      • creating Scoop Manifest
   • RUNNING BEFORE HOOKS
   • CHECKING ./DIST
   • GETTING AND VALIDATING GIT STATE
      • releasing v0.0.1, commit 630080600cc711a1e1aa0210a41703a77fe5ffd0
   • WRITING EFFECTIVE CONFIG FILE
      • writing                   config=dist/config.yaml
   • GENERATING CHANGELOG
      • writing                   changelog=dist/CHANGELOG.md
   • LOADING ENVIRONMENT VARIABLES
   • BUILDING BINARIES
      • building                  binary=dist/linux_arm64/kauri-api
      • building                  binary=dist/linux_386/kauri-api
      • building                  binary=dist/linux_arm_6/kauri-api
      • building                  binary=dist/linux_amd64/kauri-api
      • added new artifact        name=kauri-api path=dist/linux_arm_6/kauri-api type=%!s(artifact.Type=2)
      • building                  binary=dist/darwin_amd64/kauri-api
      • added new artifact        name=kauri-api path=dist/linux_386/kauri-api type=%!s(artifact.Type=2)
      • added new artifact        name=kauri-api path=dist/linux_amd64/kauri-api type=%!s(artifact.Type=2)
      • added new artifact        name=kauri-api path=dist/linux_arm64/kauri-api type=%!s(artifact.Type=2)
      • added new artifact        name=kauri-api path=dist/darwin_amd64/kauri-api type=%!s(artifact.Type=2)
   • CREATING ARCHIVES
      • creating                  archive=dist/kauri-api_0.0.1_Linux_arm64.tar.gz
      • creating                  archive=dist/kauri-api_0.0.1_Darwin_x86_64.tar.gz
      • creating                  archive=dist/kauri-api_0.0.1_Linux_armv6.tar.gz
      • creating                  archive=dist/kauri-api_0.0.1_Linux_i386.tar.gz
      • creating                  archive=dist/kauri-api_0.0.1_Linux_x86_64.tar.gz
      • added new artifact        name=kauri-api_0.0.1_Linux_i386.tar.gz path=dist/kauri-api_0.0.1_Linux_i386.tar.gz type=%!s(artifact.Type=0)
      • added new artifact        name=kauri-api_0.0.1_Linux_arm64.tar.gz path=dist/kauri-api_0.0.1_Linux_arm64.tar.gz type=%!s(artifact.Type=0)
      • added new artifact        name=kauri-api_0.0.1_Linux_armv6.tar.gz path=dist/kauri-api_0.0.1_Linux_armv6.tar.gz type=%!s(artifact.Type=0)
      • added new artifact        name=kauri-api_0.0.1_Linux_x86_64.tar.gz path=dist/kauri-api_0.0.1_Linux_x86_64.tar.gz type=%!s(artifact.Type=0)
      • added new artifact        name=kauri-api_0.0.1_Darwin_x86_64.tar.gz path=dist/kauri-api_0.0.1_Darwin_x86_64.tar.gz type=%!s(artifact.Type=0)
   • CREATING LINUX PACKAGES WITH NFPM
      • skipped                   reason=no output formats configured
   • CREATING LINUX PACKAGES WITH SNAPCRAFT
      • skipped                   reason=no summary nor description were provided
   • CALCULATING CHECKSUMS
      • checksumming              file=kauri-api_0.0.1_Linux_i386.tar.gz
      • checksumming              file=kauri-api_0.0.1_Linux_x86_64.tar.gz
      • checksumming              file=kauri-api_0.0.1_Linux_arm64.tar.gz
      • checksumming              file=kauri-api_0.0.1_Linux_armv6.tar.gz
      • added new artifact        name=kauri-api_0.0.1_checksums.txt path=dist/kauri-api_0.0.1_checksums.txt type=%!s(artifact.Type=5)
      • checksumming              file=kauri-api_0.0.1_Darwin_x86_64.tar.gz
   • SIGNING ARTIFACTS
      • added new artifact        name=kauri-api_0.0.1_checksums.txt.sig path=dist/kauri-api_0.0.1_checksums.txt.sig type=%!s(artifact.Type=6)
   • CREATING DOCKER IMAGES
      • skipped                   reason=docker section is not configured
   • RELEASING TO ARTIFACTORY
      • skipped                   reason=artifactory section is not configured
   • RELEASING TO S3
   • RELEASING TO GITHUB
      • creating or updating release repo=Encrypt-S/kauri-api tag=v0.0.1
      • release updated           url=https://github.com/Encrypt-S/kauri-api/releases/tag/v0.0.1
      • uploading to release      file=dist/kauri-api_0.0.1_Linux_x86_64.tar.gz name=kauri-api_0.0.1_Linux_x86_64.tar.gz
      • uploading to release      file=dist/kauri-api_0.0.1_Linux_armv6.tar.gz name=kauri-api_0.0.1_Linux_armv6.tar.gz
      • uploading to release      file=dist/kauri-api_0.0.1_Linux_i386.tar.gz name=kauri-api_0.0.1_Linux_i386.tar.gz
      • uploading to release      file=dist/kauri-api_0.0.1_Linux_arm64.tar.gz name=kauri-api_0.0.1_Linux_arm64.tar.gz
      • uploading to release      file=dist/kauri-api_0.0.1_Darwin_x86_64.tar.gz name=kauri-api_0.0.1_Darwin_x86_64.tar.gz
      • uploading to release      file=dist/kauri-api_0.0.1_checksums.txt name=kauri-api_0.0.1_checksums.txt
      • uploading to release      file=dist/kauri-api_0.0.1_checksums.txt.sig name=kauri-api_0.0.1_checksums.txt.sig
   • CREATING HOMEBREW FORMULA
      • skipped                   reason=brew section is not configured
   • CREATING SCOOP MANIFEST
      • skipped                   reason=scoop section is not configured
   • release succeeded after 30.46s```

info on goreleaser - https://goreleaser.com/